### PR TITLE
rm type='css' when import styles

### DIFF
--- a/px-vis-timeseries.html
+++ b/px-vis-timeseries.html
@@ -36,7 +36,7 @@ Creates an interactive timeseries chart
 @demo demo.html
 -->
 
-<link rel="import" type="css" href="css/px-vis-timeseries-styles.html"/>
+<link rel="import" href="css/px-vis-timeseries-styles.html"/>
 
 <dom-module id="px-vis-timeseries">
   <template>


### PR DESCRIPTION
Hi,
I'm Hongxun in Digital-Foundry@Shanghai.

The `type="css"` may cause `vulcanize` generate error bundle file. Because the `px-vis-timeseries-styles` is an Element, but not a css file.

Here is the vulcanized file created by `gulp-vulcanize` in my project:

```
<dom-module id="home-dashboard-view" assetpath="elements/views/">
  <template><style>
<dom-module id="px-vis-timeseries-styles">
<template>
<style>
```

You can see, the `px-vis-timeseries-styles` is put the wrong place, it broke `home-dashboard-view` element. But It will be OK after I remove `type="css"` in `px-vis-timeseries`.