### PR TITLE
add hideToolbar prop & observer; add hideToolbar to demo

### DIFF
--- a/demo/px-vis-timeseries-demo.html
+++ b/demo/px-vis-timeseries-demo.html
@@ -58,6 +58,7 @@
           tooltip-config='{{props.tooltipConfig.value}}'
           show-tooltip='{{props.showTooltip.value}}'
           hide-register='{{props.hideRegister.value}}'
+          hide-toolbar='{{props.hideToolbar.value}}'
           hide-gridlines-x='{{props.hideGridlinesX.value}}'
           hide-gridlines-y='{{props.hideGridlinesY.value}}'
           series-config='{{props.seriesConfig.value}}'
@@ -390,6 +391,12 @@
       },
 
       hideRegister: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      hideToolbar: {
         type: Boolean,
         defaultValue: false,
         inputType: 'toggle'

--- a/px-vis-timeseries.html
+++ b/px-vis-timeseries.html
@@ -688,6 +688,14 @@ Custom property | Description
         observer: '_disableNavigatorChanged'
       },
       /**
+       * Whether to hide the toolbar
+       */
+      hideToolbar: {
+        type: Boolean,
+        value: false,
+        observer: '_hideToolbarChanged'
+      },
+      /**
        * Whether to hide the gridlines perpendicular to the X axis
        */
       hideGridlinesX: {
@@ -1086,6 +1094,19 @@ Custom property | Description
         //make sure dom if is rendered
         this.$.navTemplate.render();
         this._navigatorConfigChanged();
+      }
+    },
+
+    /**
+     *
+     *
+     */
+    _hideToolbarChanged: function() {
+      if(this.hideToolbar) {
+        this.$.toolbar.style.display = 'none';
+      }
+      else {
+        this.$.toolbar.style.display = '';
       }
     },
 


### PR DESCRIPTION
Fixes #36. 
- New property hideToolbar to toggle toolbar on and off.  
- Observer method just adds and removes the "display: none" style from the px-vis-toolbar element.  
- Does not interfere with sizing
- Added to demo and tested